### PR TITLE
chore(security): override fast-uri to >=3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6046,6 +6046,7 @@
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6055,6 +6056,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8664,6 +8666,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -9819,9 +9822,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -16536,6 +16539,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -46,5 +46,8 @@
     "@vitest/ui": "^4.0.16",
     "typescript": "^6.0.0",
     "vitest": "^4.0.16"
+  },
+  "overrides": {
+    "fast-uri": ">=3.1.2"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `overrides` block to `package.json` forcing `fast-uri >= 3.1.2`
- Clears the two remaining open Dependabot alerts (both `fast-uri`)
- Transitive path: `@astrojs/check` → `yaml-language-server` → `ajv` → `fast-uri`

## Why an override
`ajv@8.18.0` resolves `fast-uri@3.1.0`. The upstream `ajv` has not bumped its `fast-uri` range, so the only quick fix is an npm `overrides` block.

Patched advisories:
- GHSA host confusion via percent-encoded authority delimiters (patched in 3.1.2)
- GHSA path traversal via percent-encoded dot segments (patched in 3.1.1)

## Test plan
- [x] `npm install` regenerates lockfile cleanly (`fast-uri@3.1.2` resolved)
- [x] `npm run build` passes
- [x] `npm run test:unit` passes (14 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)