### PR TITLE
feat(ui): add site-wide footer with privacy link and copyright

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,16 @@
+---
+const year = new Date().getFullYear();
+---
+
+<footer class="border-t border-border/40 py-6 text-sm text-muted-foreground">
+	<div class="container mx-auto flex flex-col items-center justify-between gap-3 px-4 sm:flex-row">
+		<p>&copy; {year} Vyas Ramankulangara. All rights reserved.</p>
+		<nav aria-label="Footer">
+			<a
+				href="/privacy"
+				class="hover:text-foreground hover:underline focus-visible:text-foreground focus-visible:outline-none focus-visible:underline"
+				>Privacy Policy</a
+			>
+		</nav>
+	</div>
+</footer>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -3,7 +3,6 @@ const links = [
 	{ href: '/', label: 'Home' },
 	{ href: '/about', label: 'About' },
 	{ href: '/contact', label: 'Contact' },
-	{ href: '/privacy', label: 'Privacy' },
 ];
 
 const currentPath = Astro.url.pathname;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,11 +1,12 @@
 ---
-import Layout from '@/layouts/Layout.astro';
+import Footer from '@/components/Footer.astro';
 import Navigation from '@/components/Navigation.astro';
+import Layout from '@/layouts/Layout.astro';
 ---
 
 <Layout title="404 — Page Not Found" description="The page you're looking for doesn't exist.">
   <Navigation slot="header" />
-  <section class="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center text-center px-4">
+  <section class="flex flex-1 flex-col items-center justify-center text-center px-4 py-16">
     <p class="text-sm uppercase tracking-widest text-muted-foreground">Error 404</p>
     <h1 class="mt-2 text-5xl font-bold sm:text-6xl">Page not found</h1>
     <p class="mt-4 max-w-md text-muted-foreground">
@@ -25,8 +26,7 @@ import Navigation from '@/components/Navigation.astro';
         Contact me
       </a>
     </div>
-    <p class="mt-6 text-xs text-muted-foreground">
-      Or read the <a href="/privacy" class="underline hover:text-foreground">privacy policy</a>.
-    </p>
   </section>
+
+  <Footer slot="footer" />
 </Layout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,8 +1,9 @@
 ---
-import Layout from '@/layouts/Layout.astro';
+import Footer from '@/components/Footer.astro';
 import Navigation from '@/components/Navigation.astro';
-import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import Layout from '@/layouts/Layout.astro';
 import { Code2, Database, GitBranch, Server } from 'lucide-react';
 
 const skills = {
@@ -201,4 +202,6 @@ const certifications = [
 			</div>
 		</div>
 	</div>
+
+	<Footer slot='footer' />
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,8 +1,9 @@
 ---
-import Layout from '@/layouts/Layout.astro';
+import Footer from '@/components/Footer.astro';
 import Navigation from '@/components/Navigation.astro';
 import { ContactForm } from '@/components/contact-form';
 import { Toaster } from '@/components/ui/sonner';
+import Layout from '@/layouts/Layout.astro';
 ---
 
 <Layout
@@ -14,4 +15,6 @@ import { Toaster } from '@/components/ui/sonner';
 		<ContactForm client:visible />
 	</div>
 	<Toaster client:idle />
+
+	<Footer slot='footer' />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,9 @@
 ---
-import Layout from '@/layouts/Layout.astro';
+import Footer from '@/components/Footer.astro';
 import Navigation from '@/components/Navigation.astro';
 import Hero from '@/components/sections/Hero.astro';
 import Skills from '@/components/sections/Skills.astro';
+import Layout from '@/layouts/Layout.astro';
 ---
 
 <Layout
@@ -18,4 +19,6 @@ import Skills from '@/components/sections/Skills.astro';
 			</div>
 		</div>
 	</div>
+
+	<Footer slot='footer' />
 </Layout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,10 +1,13 @@
 ---
+import Footer from '@/components/Footer.astro';
+import Navigation from '@/components/Navigation.astro';
 import Layout from '@/layouts/Layout.astro';
 
 const lastUpdated = '2026-05-27';
 ---
 
 <Layout title="Privacy Policy — Vyas Ramankulangara" description="How this site handles your data.">
+  <Navigation slot="header" />
   <section class="max-w-3xl mx-auto px-4 py-16">
     <h1 class="text-4xl font-bold mb-2">Privacy Policy</h1>
     <p class="text-sm text-muted-foreground mb-12">Last updated: {lastUpdated}</p>
@@ -36,4 +39,6 @@ const lastUpdated = '2026-05-27';
       </section>
     </div>
   </section>
+
+  <Footer slot="footer" />
 </Layout>

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -46,7 +46,7 @@ test.describe('Homepage', () => {
 		await page.goto('/');
 
 		await expect(page.locator('body')).toBeVisible();
-		const nav = page.locator('nav');
+		const nav = page.locator('header nav');
 		await expect(nav).toBeVisible();
 	});
 

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -4,8 +4,8 @@ test.describe('Navigation', () => {
 	test('should have working navigation links', async ({ page }) => {
 		await page.goto('/');
 
-		// Check if navigation exists
-		const nav = page.locator('nav');
+		// Scope to the header nav (the footer also has a <nav> landmark).
+		const nav = page.locator('header nav');
 		await expect(nav).toBeVisible();
 
 		// Check for navigation links in the header nav (not the hero buttons)
@@ -22,7 +22,7 @@ test.describe('Navigation', () => {
 		await page.goto('/');
 
 		// Use the nav link, not the hero button
-		const aboutLink = page.locator('nav').getByRole('link', { name: 'About', exact: true });
+		const aboutLink = page.locator('header nav').getByRole('link', { name: 'About', exact: true });
 		await aboutLink.click();
 
 		await expect(page).toHaveURL(/\/about/);
@@ -33,7 +33,9 @@ test.describe('Navigation', () => {
 		await page.goto('/');
 
 		// Use the nav link, not the hero button
-		const contactLink = page.locator('nav').getByRole('link', { name: 'Contact', exact: true });
+		const contactLink = page
+			.locator('header nav')
+			.getByRole('link', { name: 'Contact', exact: true });
 		await contactLink.click();
 
 		await expect(page).toHaveURL(/\/contact/);
@@ -43,7 +45,7 @@ test.describe('Navigation', () => {
 	test('should navigate back to Home page', async ({ page }) => {
 		await page.goto('/about');
 
-		const homeLink = page.locator('nav').getByRole('link', { name: 'Home', exact: true });
+		const homeLink = page.locator('header nav').getByRole('link', { name: 'Home', exact: true });
 		await homeLink.click();
 
 		await expect(page).toHaveURL('/');


### PR DESCRIPTION
## Summary

Adds a shared footer to all pages: copyright + Privacy Policy link. Moves the Privacy entry out of the top nav (better fit as a footer/legal item).

## Changes

- New \`src/components/Footer.astro\` — © {year} Vyas Ramankulangara · Privacy Policy
- Mounted in the existing \`footer\` slot on all 5 pages (index, about, contact, privacy, 404)
- Removed \`Privacy\` from \`Navigation.astro\` links array
- 404 page: dropped the inline privacy escape-hatch (footer covers it now) and switched to \`flex-1\` so the footer sits flush at the bottom

## Verified locally
- \`npm run typecheck\` ✓
- \`npm run lint\` / \`npm run format:check\` ✓ (Biome)
- \`npm run build\` ✓ (4 static pages + 404 + OG images + sitemap)
- \`npm run test:unit\` ✓ (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)