### PR TITLE
fix(test): drop unsafe regex escape in contact-form test (CodeQL #12)

### DIFF
--- a/tests/unit/contact-form.test.tsx
+++ b/tests/unit/contact-form.test.tsx
@@ -107,9 +107,8 @@ describe('ContactForm', () => {
 		await user.click(screen.getByRole('button', { name: /send message/i }));
 
 		expect(await screen.findByRole('status')).toHaveTextContent(/email service is having issues/i);
-		expect(await screen.findByRole('status')).toHaveTextContent(
-			new RegExp(CONTACT_EMAIL.replace(/[.+]/g, '\\$&'), 'i'),
-		);
+		// Plain string does substring match — no regex escaping needed.
+		expect(await screen.findByRole('status')).toHaveTextContent(CONTACT_EMAIL);
 
 		// A mailto link exists somewhere in the DOM (either contact info or toast).
 		const mailtoLinks = screen


### PR DESCRIPTION
## Summary

Resolves CodeQL alert [#12](https://github.com/vyas0189/vyas/security/code-scanning/12) — `js/incomplete-sanitization` (High severity).

The expression \`new RegExp(CONTACT_EMAIL.replace(/[.+]/g, '\\\\\$&'), 'i')\` only escaped \`.\` and \`+\`, missing other regex meta-chars (including \`\\\` itself).

\`CONTACT_EMAIL\` is a hardcoded constant (\`vyas0189@gmail.com\`) so there's no actual injection risk, but the cleanest fix is to **drop the regex entirely**: \`toHaveTextContent\` already does substring matching when given a plain string.

## Verified
- \`npm run test:unit\` — 41/41 pass
- \`npm run lint\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)