### PR TITLE
chore: remove unused Upstash rate-limit branch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,3 @@ RESEND_TO_EMAIL=your-email@example.com
 PUBLIC_SENTRY_DSN=https://your-public-dsn@sentry.io/project-id
 SENTRY_DSN=https://your-public-dsn@sentry.io/project-id
 SENTRY_AUTH_TOKEN=sntrys_your_token_here
-
-# Upstash Redis rate limiting (optional; falls back to in-memory if unset)
-UPSTASH_REDIS_REST_URL=
-UPSTASH_REDIS_REST_TOKEN=

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Netlify's git-driven auto-build should be disabled in the Netlify UI; CI is the 
 
 See `.env.example`. The contact form's API route (`/api/emails`) needs all `RESEND_*` values. Sentry vars are optional but recommended for production.
 
-Optional: `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` enable Redis-backed rate limiting (3 submissions per 60s per IP). Without them the API falls back to an in-memory limiter, which is per-instance only on Netlify Functions and effectively cosmetic in production.
+The contact form is rate-limited (3 submissions per 60s per IP) using an in-memory map. On Netlify Functions this is per-instance and best-effort — if abuse becomes a concern, swap in a distributed limiter (Upstash, Netlify Blobs, etc.).
 
 ## Architecture notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,6 @@
 				"@react-email/components": "^1.0.0",
 				"@sentry/astro": "^10.17.0",
 				"@tailwindcss/vite": "^4.1.13",
-				"@upstash/ratelimit": "^2.0.8",
-				"@upstash/redis": "^1.38.0",
 				"astro": "^6.0.0",
 				"astro-og-canvas": "^0.11.1",
 				"canvaskit-wasm": "^0.41.1",
@@ -6719,40 +6717,6 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
 			"integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
 			"license": "ISC"
-		},
-		"node_modules/@upstash/core-analytics": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
-			"integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@upstash/redis": "^1.28.3"
-			},
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@upstash/ratelimit": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
-			"integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
-			"license": "MIT",
-			"dependencies": {
-				"@upstash/core-analytics": "^0.0.10"
-			},
-			"peerDependencies": {
-				"@upstash/redis": "^1.34.3"
-			}
-		},
-		"node_modules/@upstash/redis": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
-			"integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"uncrypto": "^0.1.3"
-			}
 		},
 		"node_modules/@vercel/nft": {
 			"version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,6 @@
 		"@react-email/components": "^1.0.0",
 		"@sentry/astro": "^10.17.0",
 		"@tailwindcss/vite": "^4.1.13",
-		"@upstash/ratelimit": "^2.0.8",
-		"@upstash/redis": "^1.38.0",
 		"astro": "^6.0.0",
 		"astro-og-canvas": "^0.11.1",
 		"canvaskit-wasm": "^0.41.1",

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,42 +1,19 @@
-import { Ratelimit } from '@upstash/ratelimit';
-import { Redis } from '@upstash/redis';
+// In-memory sliding-window rate limiter. Per-instance only — on Netlify
+// Functions each cold-start gets its own Map, so this is best-effort and
+// cosmetic in production. Good enough for a personal portfolio's contact form;
+// swap for a distributed limiter (Upstash, Netlify Blobs, etc.) if abuse
+// becomes a concern.
 
 const RATE_LIMIT = 3;
 const RATE_WINDOW_MS = 60_000;
 
-const UPSTASH_REDIS_REST_URL =
-	process.env.UPSTASH_REDIS_REST_URL || import.meta.env.UPSTASH_REDIS_REST_URL;
-const UPSTASH_REDIS_REST_TOKEN =
-	process.env.UPSTASH_REDIS_REST_TOKEN || import.meta.env.UPSTASH_REDIS_REST_TOKEN;
-
-const hasUpstash = Boolean(UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN);
-
-let ratelimit: Ratelimit | null = null;
-
-if (hasUpstash) {
-	const redis = new Redis({
-		url: UPSTASH_REDIS_REST_URL as string,
-		token: UPSTASH_REDIS_REST_TOKEN as string,
-	});
-
-	ratelimit = new Ratelimit({
-		redis,
-		limiter: Ratelimit.slidingWindow(RATE_LIMIT, `${RATE_WINDOW_MS} ms`),
-		prefix: 'email-form',
-		analytics: false,
-	});
-} else {
-	console.warn('rate-limit: falling back to in-memory (Upstash env vars missing)');
-}
-
-// In-memory fallback store
 const memoryStore = new Map<string, { count: number; resetAt: number }>();
 
-function checkInMemory(ip: string): {
+export async function checkRateLimit(ip: string): Promise<{
 	success: boolean;
 	remaining: number;
 	reset: number;
-} {
+}> {
 	const now = Date.now();
 	const entry = memoryStore.get(ip);
 
@@ -53,21 +30,4 @@ function checkInMemory(ip: string): {
 		remaining,
 		reset: entry.resetAt,
 	};
-}
-
-export async function checkRateLimit(ip: string): Promise<{
-	success: boolean;
-	remaining: number;
-	reset: number;
-}> {
-	if (ratelimit) {
-		const result = await ratelimit.limit(`email-form:${ip}`);
-		return {
-			success: result.success,
-			remaining: result.remaining,
-			reset: result.reset,
-		};
-	}
-
-	return checkInMemory(ip);
 }

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,23 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-const originalEnv = { ...process.env };
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 beforeEach(() => {
+	// Each test gets a fresh in-memory store via module re-import.
 	vi.resetModules();
-	vi.doUnmock('@upstash/ratelimit');
-	vi.doUnmock('@upstash/redis');
-	process.env = { ...originalEnv };
-	delete process.env.UPSTASH_REDIS_REST_URL;
-	delete process.env.UPSTASH_REDIS_REST_TOKEN;
 });
 
-afterEach(() => {
-	process.env = originalEnv;
-	vi.restoreAllMocks();
-	vi.unstubAllEnvs();
-});
-
-describe('checkRateLimit (in-memory fallback)', () => {
+describe('checkRateLimit', () => {
 	it('allows the first 3 requests in a window', async () => {
 		const { checkRateLimit } = await import('@/lib/rate-limit');
 		const r1 = await checkRateLimit('1.2.3.4');
@@ -86,111 +74,5 @@ describe('checkRateLimit (in-memory fallback)', () => {
 		} finally {
 			vi.useRealTimers();
 		}
-	});
-});
-
-describe('checkRateLimit (Upstash branch)', () => {
-	it('uses Upstash when env vars are set', async () => {
-		process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
-		process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
-
-		const limitMock = vi.fn().mockResolvedValue({
-			success: true,
-			remaining: 2,
-			reset: Date.now() + 60_000,
-		});
-		const redisCtor = vi.fn();
-		const ratelimitCtor = vi.fn();
-
-		vi.doMock('@upstash/ratelimit', () => ({
-			Ratelimit: class {
-				static slidingWindow(..._args: unknown[]) {
-					return { type: 'sliding-window' };
-				}
-				constructor(opts: unknown) {
-					ratelimitCtor(opts);
-				}
-				limit = limitMock;
-			},
-		}));
-		vi.doMock('@upstash/redis', () => ({
-			Redis: class {
-				constructor(opts: unknown) {
-					redisCtor(opts);
-				}
-			},
-		}));
-
-		const { checkRateLimit } = await import('@/lib/rate-limit');
-		const r = await checkRateLimit('9.9.9.9');
-
-		expect(r.success).toBe(true);
-		expect(r.remaining).toBe(2);
-		expect(limitMock).toHaveBeenCalledTimes(1);
-		// Module prefixes the key with "email-form:" — confirm IP is in the key.
-		expect(limitMock.mock.calls[0][0]).toEqual(expect.stringContaining('9.9.9.9'));
-		// Redis was constructed with the env credentials.
-		expect(redisCtor).toHaveBeenCalledWith(
-			expect.objectContaining({
-				url: 'https://example.upstash.io',
-				token: 'fake-token',
-			}),
-		);
-		// Ratelimit was constructed with a redis instance and a limiter.
-		expect(ratelimitCtor).toHaveBeenCalledTimes(1);
-	});
-
-	it('propagates Upstash failure (success: false)', async () => {
-		process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
-		process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
-
-		const resetTs = Date.now() + 60_000;
-		const limitMock = vi.fn().mockResolvedValue({
-			success: false,
-			remaining: 0,
-			reset: resetTs,
-		});
-
-		vi.doMock('@upstash/ratelimit', () => ({
-			Ratelimit: class {
-				static slidingWindow(..._args: unknown[]) {
-					return {};
-				}
-				limit = limitMock;
-			},
-		}));
-		vi.doMock('@upstash/redis', () => ({
-			Redis: class {},
-		}));
-
-		const { checkRateLimit } = await import('@/lib/rate-limit');
-		const r = await checkRateLimit('10.0.0.1');
-
-		expect(r.success).toBe(false);
-		expect(r.remaining).toBe(0);
-		expect(r.reset).toBe(resetTs);
-	});
-
-	it('falls back to in-memory when only one Upstash env var is set', async () => {
-		process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
-		// UPSTASH_REDIS_REST_TOKEN intentionally missing.
-
-		const limitMock = vi.fn();
-		vi.doMock('@upstash/ratelimit', () => ({
-			Ratelimit: class {
-				static slidingWindow() {
-					return {};
-				}
-				limit = limitMock;
-			},
-		}));
-		vi.doMock('@upstash/redis', () => ({
-			Redis: class {},
-		}));
-
-		const { checkRateLimit } = await import('@/lib/rate-limit');
-		const r = await checkRateLimit('partial-env');
-		expect(r.success).toBe(true);
-		expect(limitMock).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

The Upstash-backed rate-limit path was wired in earlier as a forward-looking option but never actually used in production (env vars were never set in Netlify, so the code always took the in-memory fallback). Removing the dead code.

## Changes

- Drop \`@upstash/ratelimit\` + \`@upstash/redis\` direct dependencies
- Simplify \`src/lib/rate-limit.ts\` to in-memory only (sliding 60s window, 3 req/IP)
- Remove \`UPSTASH_REDIS_REST_URL\` / \`UPSTASH_REDIS_REST_TOKEN\` from \`.env.example\`
- Drop the 3 Upstash-branch unit tests (38/38 pass total, was 41)
- README: rephrase the rate-limit note; mention Upstash / Netlify Blobs as future options if abuse becomes a concern

## Side effect

Closes out a leaked-token concern from earlier security reviews — the leaked token granted access to a Redis DB that nothing was using, so the cleanest fix was to remove the integration entirely rather than rotate a credential we don't need.

## Verified locally
- \`npm run typecheck\` ✓
- \`npm run lint\` / \`npm run format:check\` ✓
- \`npm run build\` ✓
- \`npm run test:unit\` ✓ (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)