### PR TITLE
feat(rate-limit): back contact form rate-limit with Netlify Blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Netlify's git-driven auto-build should be disabled in the Netlify UI; CI is the 
 
 See `.env.example`. The contact form's API route (`/api/emails`) needs all `RESEND_*` values. Sentry vars are optional but recommended for production.
 
-The contact form is rate-limited (3 submissions per 60s per IP) using an in-memory map. On Netlify Functions this is per-instance and best-effort — if abuse becomes a concern, swap in a distributed limiter (Upstash, Netlify Blobs, etc.).
+The contact form is rate-limited to **3 submissions per 60s per IP**, backed by [Netlify Blobs](https://docs.netlify.com/blobs/overview/) so the limit holds across cold starts and function instances. When Blobs is unavailable (e.g., local `astro dev` without `netlify dev`) the limiter falls back to an in-memory map for the same window.
 
 ## Architecture notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@astrojs/sitemap": "^3.7.3",
 				"@fontsource-variable/inter": "^5.2.8",
 				"@hookform/resolvers": "^5.2.2",
+				"@netlify/blobs": "^10.7.8",
 				"@radix-ui/react-label": "^2.1.7",
 				"@radix-ui/react-slot": "^1.2.3",
 				"@react-email/components": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"@astrojs/sitemap": "^3.7.3",
 		"@fontsource-variable/inter": "^5.2.8",
 		"@hookform/resolvers": "^5.2.2",
+		"@netlify/blobs": "^10.7.8",
 		"@radix-ui/react-label": "^2.1.7",
 		"@radix-ui/react-slot": "^1.2.3",
 		"@react-email/components": "^1.0.0",

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,19 +1,45 @@
-// In-memory sliding-window rate limiter. Per-instance only — on Netlify
-// Functions each cold-start gets its own Map, so this is best-effort and
-// cosmetic in production. Good enough for a personal portfolio's contact form;
-// swap for a distributed limiter (Upstash, Netlify Blobs, etc.) if abuse
-// becomes a concern.
+// Distributed rate limiter backed by Netlify Blobs, with in-memory fallback
+// for local dev and any environment where Blobs is unavailable.
+//
+// On Netlify Functions, Blobs gives us a key-value store that survives across
+// cold starts and function instances — so a determined attacker can't bypass
+// the limit by hitting different containers. Locally (astro dev without
+// `netlify dev`) the Blobs SDK throws on access, so we fall back to a
+// per-process Map.
+//
+// Note: Blobs is eventually-consistent. Concurrent requests from the same IP
+// in the exact same 100ms window could both see a stale count and both
+// succeed at the limit boundary. For a personal portfolio contact form this
+// race is acceptable (worst case: a couple extra messages slip through per
+// cold start).
+
+import { getStore, type Store } from '@netlify/blobs';
 
 const RATE_LIMIT = 3;
 const RATE_WINDOW_MS = 60_000;
 
-const memoryStore = new Map<string, { count: number; resetAt: number }>();
+type Entry = { count: number; resetAt: number };
 
-export async function checkRateLimit(ip: string): Promise<{
+const memoryStore = new Map<string, Entry>();
+
+let blobStore: Store | null | undefined;
+
+function getBlobStore(): Store | null {
+	if (blobStore !== undefined) return blobStore;
+	try {
+		blobStore = getStore({ name: 'rate-limit', consistency: 'strong' });
+	} catch {
+		// Local dev / non-Netlify environment — Blobs SDK throws without context.
+		blobStore = null;
+	}
+	return blobStore;
+}
+
+function checkInMemory(ip: string): {
 	success: boolean;
 	remaining: number;
 	reset: number;
-}> {
+} {
 	const now = Date.now();
 	const entry = memoryStore.get(ip);
 
@@ -30,4 +56,48 @@ export async function checkRateLimit(ip: string): Promise<{
 		remaining,
 		reset: entry.resetAt,
 	};
+}
+
+async function checkInBlobs(
+	store: Store,
+	ip: string,
+): Promise<{ success: boolean; remaining: number; reset: number }> {
+	const now = Date.now();
+	const key = `ip:${ip}`;
+	const existing = (await store.get(key, { type: 'json' })) as Entry | null;
+
+	if (!existing || now > existing.resetAt) {
+		const resetAt = now + RATE_WINDOW_MS;
+		await store.setJSON(key, { count: 1, resetAt });
+		return { success: true, remaining: RATE_LIMIT - 1, reset: resetAt };
+	}
+
+	const nextCount = existing.count + 1;
+	const remaining = Math.max(0, RATE_LIMIT - nextCount);
+	await store.setJSON(key, { count: nextCount, resetAt: existing.resetAt });
+	return {
+		success: nextCount <= RATE_LIMIT,
+		remaining,
+		reset: existing.resetAt,
+	};
+}
+
+export async function checkRateLimit(ip: string): Promise<{
+	success: boolean;
+	remaining: number;
+	reset: number;
+}> {
+	const store = getBlobStore();
+	if (!store) return checkInMemory(ip);
+
+	try {
+		return await checkInBlobs(store, ip);
+	} catch (err) {
+		// Blobs unreachable mid-request — fall back to in-memory rather than
+		// failing the user's submission outright.
+		console.warn('rate-limit: Blobs unavailable, falling back to memory', {
+			name: (err as Error)?.name,
+		});
+		return checkInMemory(ip);
+	}
 }

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,61 +1,140 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 beforeEach(() => {
-	// Each test gets a fresh in-memory store via module re-import.
+	// Each test gets a fresh module state (fresh in-memory Map + re-evaluated
+	// Blobs getStore lookup) via re-import.
 	vi.resetModules();
+	vi.unstubAllEnvs();
 });
 
-describe('checkRateLimit', () => {
+// --- helpers ---
+
+function makeBlobMap() {
+	const map = new Map<string, unknown>();
+	return {
+		map,
+		store: {
+			get: vi.fn(async (key: string, _opts?: unknown) => map.get(key) ?? null),
+			setJSON: vi.fn(async (key: string, value: unknown) => {
+				map.set(key, value);
+			}),
+		},
+	};
+}
+
+/**
+ * Mocks @netlify/blobs so the rate-limit module picks up the in-memory fake
+ * store instead of attempting to talk to Netlify. Must be called before
+ * importing the module under test.
+ */
+function mockBlobsAvailable(store: unknown) {
+	vi.doMock('@netlify/blobs', () => ({
+		getStore: vi.fn(() => store),
+	}));
+}
+
+function mockBlobsUnavailable() {
+	vi.doMock('@netlify/blobs', () => ({
+		getStore: vi.fn(() => {
+			throw new Error('MissingBlobsEnvironmentError');
+		}),
+	}));
+}
+
+// --- Blobs-backed path (primary) ---
+
+describe('checkRateLimit (Netlify Blobs)', () => {
 	it('allows the first 3 requests in a window', async () => {
+		const { store } = makeBlobMap();
+		mockBlobsAvailable(store);
 		const { checkRateLimit } = await import('@/lib/rate-limit');
+
 		const r1 = await checkRateLimit('1.2.3.4');
 		const r2 = await checkRateLimit('1.2.3.4');
 		const r3 = await checkRateLimit('1.2.3.4');
+
 		expect(r1.success).toBe(true);
 		expect(r2.success).toBe(true);
 		expect(r3.success).toBe(true);
 	});
 
 	it('reports decreasing remaining counts within the window', async () => {
+		const { store } = makeBlobMap();
+		mockBlobsAvailable(store);
 		const { checkRateLimit } = await import('@/lib/rate-limit');
+
 		const r1 = await checkRateLimit('remaining-test');
 		const r2 = await checkRateLimit('remaining-test');
 		const r3 = await checkRateLimit('remaining-test');
+
 		expect(r1.remaining).toBe(2);
 		expect(r2.remaining).toBe(1);
 		expect(r3.remaining).toBe(0);
 	});
 
 	it('blocks the 4th request in a window', async () => {
+		const { store } = makeBlobMap();
+		mockBlobsAvailable(store);
 		const { checkRateLimit } = await import('@/lib/rate-limit');
+
 		await checkRateLimit('5.6.7.8');
 		await checkRateLimit('5.6.7.8');
 		await checkRateLimit('5.6.7.8');
 		const r4 = await checkRateLimit('5.6.7.8');
+
 		expect(r4.success).toBe(false);
 		expect(r4.remaining).toBe(0);
 	});
 
 	it('isolates by IP', async () => {
+		const { store } = makeBlobMap();
+		mockBlobsAvailable(store);
 		const { checkRateLimit } = await import('@/lib/rate-limit');
+
 		await checkRateLimit('ip-a');
 		await checkRateLimit('ip-a');
 		await checkRateLimit('ip-a');
 		const blockedA = await checkRateLimit('ip-a');
 		const freshB = await checkRateLimit('ip-b');
+
 		expect(blockedA.success).toBe(false);
 		expect(freshB.success).toBe(true);
 	});
 
+	it('persists across module re-imports (simulating cold starts)', async () => {
+		// Same fake store, different module instances — what survives is the
+		// blob data, which is the whole point of using Blobs.
+		const { store } = makeBlobMap();
+		mockBlobsAvailable(store);
+
+		const first = await import('@/lib/rate-limit');
+		await first.checkRateLimit('persist-test');
+		await first.checkRateLimit('persist-test');
+		await first.checkRateLimit('persist-test');
+
+		vi.resetModules();
+		mockBlobsAvailable(store);
+		const second = await import('@/lib/rate-limit');
+		const r4 = await second.checkRateLimit('persist-test');
+
+		expect(r4.success).toBe(false);
+	});
+
 	it('returns a future reset timestamp within the 60s window', async () => {
+		const { store } = makeBlobMap();
+		mockBlobsAvailable(store);
 		const { checkRateLimit } = await import('@/lib/rate-limit');
+
 		const before = Date.now();
 		const r = await checkRateLimit('reset-test');
+
 		expect(r.reset).toBeGreaterThanOrEqual(before);
 		expect(r.reset).toBeLessThanOrEqual(before + 60_500);
 	});
 
 	it('resets the counter after the window elapses', async () => {
+		const { store } = makeBlobMap();
+		mockBlobsAvailable(store);
 		vi.useFakeTimers();
 		try {
 			const { checkRateLimit } = await import('@/lib/rate-limit');
@@ -65,7 +144,6 @@ describe('checkRateLimit', () => {
 			const blocked = await checkRateLimit('window-test');
 			expect(blocked.success).toBe(false);
 
-			// Advance past the 60s window.
 			vi.setSystemTime(Date.now() + 61_000);
 
 			const allowed = await checkRateLimit('window-test');
@@ -74,5 +152,36 @@ describe('checkRateLimit', () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it('falls back to in-memory if Blobs throws mid-request', async () => {
+		const failingStore = {
+			get: vi.fn(async () => {
+				throw new Error('blobs network failure');
+			}),
+			setJSON: vi.fn(),
+		};
+		mockBlobsAvailable(failingStore);
+		const { checkRateLimit } = await import('@/lib/rate-limit');
+
+		// Should not throw — should degrade to in-memory.
+		const r = await checkRateLimit('blobs-down');
+		expect(r.success).toBe(true);
+	});
+});
+
+// --- Pure in-memory fallback (Blobs unavailable, e.g. local astro dev) ---
+
+describe('checkRateLimit (in-memory fallback when Blobs is unavailable)', () => {
+	it('still rate-limits correctly when Blobs SDK throws on init', async () => {
+		mockBlobsUnavailable();
+		const { checkRateLimit } = await import('@/lib/rate-limit');
+
+		await checkRateLimit('no-blobs');
+		await checkRateLimit('no-blobs');
+		await checkRateLimit('no-blobs');
+		const blocked = await checkRateLimit('no-blobs');
+
+		expect(blocked.success).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

Replaces the in-memory-only limiter with a Netlify Blobs-backed one. The 3 req/60s/IP cap now holds **across cold starts and function instances** — a determined attacker can no longer spread requests across Function containers to bypass the cap.

## How it works

- **Primary**: Netlify Blobs store \`rate-limit\` with strong consistency, key \`ip:<addr>\` → \`{ count, resetAt }\`
- **Fallback (graceful)**: in-memory \`Map\`, triggered when:
  - \`getStore()\` throws on init (local \`astro dev\` without \`netlify dev\` context)
  - Blobs throws mid-request (network/transient failure) — better to let the user submit than 500 on infra glitches

No code changes needed in \`api/emails.ts\` — \`checkRateLimit(ip)\` signature is unchanged.

## Tests (41/41, was 38)

- Re-mocked existing rate-limit tests around the Blobs primary path
- **New**: \`persists across module re-imports (simulating cold starts)\` — asserts the underlying KV semantics that motivated this change
- **New**: graceful fallback when Blobs SDK throws on init
- **New**: graceful fallback when Blobs throws mid-request

## Dependencies

- Adds \`@netlify/blobs\` as a direct dep (was transitive via \`@astrojs/netlify\`)

## Verified locally
- \`npm run typecheck\` ✓
- \`npm run lint\` / \`npm run format:check\` ✓
- \`npm run build\` ✓ (sitemap + OG + SSR function all emit correctly)
- \`npm run test:unit\` ✓ (41/41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)