### PR TITLE
fix: correct production domain to vyasr.space (was vyasr.com)

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Ping production
         id: ping
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://vyasr.com/)
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://vyasr.space/)
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           if [ "$STATUS" != "200" ]; then
             echo "::error::Site returned HTTP $STATUS"
@@ -35,7 +35,7 @@ jobs:
           script: |
             const title = `Uptime check failed: ${new Date().toISOString().slice(0, 16)}Z`;
             const body = [
-              `The hourly uptime check against https://vyasr.com/ failed.`,
+              `The hourly uptime check against https://vyasr.space/ failed.`,
               ``,
               `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               `**Time:** ${new Date().toISOString()}`,

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://vyasr.com', // TODO: update if domain changes
+	site: 'https://vyasr.space',
 	output: 'static',
 	prefetch: {
 		prefetchAll: false,

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Allow: /
 Disallow: /api/
 
-Sitemap: https://vyasr.com/sitemap-index.xml
+Sitemap: https://vyasr.space/sitemap-index.xml


### PR DESCRIPTION
## Summary

The actual production domain is **\`vyasr.space\`**, not \`vyasr.com\` (verified via curl: \`HTTP/2 200\`, \`server: Netlify\`). \`vyasr.com\` is a different, unrelated host.

## Where this was wrong

| File | What it broke |
| --- | --- |
| \`astro.config.mjs\` (\`site\`) | sitemap URLs, absolute \`og:image\` meta, JSON-LD \`url\` field, canonical fallback |
| \`public/robots.txt\` | \`Sitemap:\` directive pointed at the wrong host |
| \`.github/workflows/uptime.yml\` | hourly cron curl'd the wrong host — would open false-positive "site down" issues once the workflow runs on main |

## Verified locally
- All three files now reference \`vyasr.space\`
- \`grep -rn "vyasr\\.com"\` → clean
- \`npm run build\` ✓ — sitemap now correctly lists \`https://vyasr.space/{,about/,contact/,privacy/}\`
- \`npm run lint\` / \`typecheck\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)