### PR TITLE
fix: security & performance audit remediations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ RESEND_TO_EMAIL=your-email@example.com
 PUBLIC_SENTRY_DSN=https://your-public-dsn@sentry.io/project-id
 SENTRY_DSN=https://your-public-dsn@sentry.io/project-id
 SENTRY_AUTH_TOKEN=sntrys_your_token_here
+
+# Optional: salt for the rate limiter's IP hashing (any random string; rotating it resets buckets)
+RATE_LIMIT_SALT=change-me-to-any-random-string

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,12 @@
 # Claude Code Instructions
 
 ## Project: vyas-portfolio
-Personal portfolio site built with Astro 6 (static), React 19 islands, Tailwind v4, deployed to Netlify. Contact form posts to a single SSR API route (`src/pages/api/emails.ts`) that sends mail via Resend. Sentry handles error reporting.
+Personal portfolio site built with Astro 7 (static), React 19 islands, Tailwind v4, deployed to Netlify. Contact form posts to a single SSR API route (`src/pages/api/emails.ts`) that sends mail via Resend. Sentry handles error reporting.
 
 ## Architecture
 - **Rendering**: `output: 'static'` in `astro.config.mjs`. Only `src/pages/api/emails.ts` opts back into SSR via `export const prerender = false;`.
-- **Middleware**: `src/middleware.ts` sets CSP and does CSRF origin check for `/api/*` POSTs. Other security headers live in `netlify.toml`. Middleware runs at the edge (`edgeMiddleware: true`).
+- **Middleware**: `src/middleware.ts` does the CSRF origin check for `/api/*` POSTs. With static output it only runs for on-demand routes — never for CDN-served pages, so page headers cannot live there. `edgeMiddleware` is off (Sentry needs Node built-ins unavailable on the Deno edge runtime).
+- **Security headers**: static headers (HSTS, XFO, nosniff, …) live in `netlify.toml`. The CSP is generated post-build into `dist/_headers` by `scripts/generate-headers.mjs` (runs via the `postbuild` npm script) because its inline-script hashes change every build — Sentry injects a per-build debug-ID snippet. Don't hardcode CSP hashes anywhere.
 - **Forms**: react-hook-form + zod (`src/lib/schemas.ts`). UI primitives are shadcn-style in `src/components/ui/`.
 - **Email**: Resend (`@react-email/components` for the template at `src/components/ui/contact-email.tsx`). The email template is server-only — keep it out of client bundles.
 - **Observability**: Sentry client + server configs at repo root. Source maps uploaded and deleted post-upload.
@@ -20,7 +21,7 @@ Personal portfolio site built with Astro 6 (static), React 19 islands, Tailwind 
 - `npm test` — both unit + e2e
 
 ## Required env vars
-See `.env.example`. Required: `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_TO_EMAIL`. Optional: `PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `SENTRY_AUTH_TOKEN`.
+See `.env.example`. Required: `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_TO_EMAIL`. Optional: `PUBLIC_SENTRY_DSN`, `SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `RATE_LIMIT_SALT` (salt for hashing IPs in the rate limiter).
 
 ## Deploy
 GitHub Actions (`.github/workflows/deploy.yml`) is the only deploy path. Netlify's git-driven build should be disabled in the Netlify UI to prevent double-deploys. PRs deploy to a Netlify preview; pushes to `main` deploy `--prod`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,7 +12,8 @@ export default defineConfig({
 	site: 'https://vyasr.space',
 	output: 'static',
 	prefetch: {
-		prefetchAll: false,
+		// Four tiny pages — prefetch every in-viewport link for instant navigation.
+		prefetchAll: true,
 		defaultStrategy: 'viewport',
 	},
 	adapter: netlify({

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,11 +16,6 @@
     Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
-  for = "/fonts/*"
-  [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
-
-[[headers]]
   for = "/favicon.svg"
   [headers.values]
     Cache-Control = "public, max-age=604800"
@@ -32,7 +27,9 @@
     X-Robots-Tag = "noindex"
     Cache-Control = "no-store"
 
-# Site-wide security headers (moved here from middleware.ts; CSP stays in middleware)
+# Site-wide security headers. The Content-Security-Policy is NOT here — it is
+# generated post-build into dist/_headers by scripts/generate-headers.mjs,
+# because its inline-script hashes change with every build (Sentry debug IDs).
 [[headers]]
   for = "/*"
   [headers.values]

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "astro dev",
 		"build": "astro build",
+		"postbuild": "node scripts/generate-headers.mjs",
 		"preview": "astro preview",
 		"check": "astro check",
 		"astro": "astro",

--- a/scripts/generate-headers.mjs
+++ b/scripts/generate-headers.mjs
@@ -1,0 +1,97 @@
+// Generates dist/_headers with a Content-Security-Policy for every CDN-served
+// page. Runs automatically after `astro build` (see the `postbuild` npm script).
+//
+// Why post-build: with `output: 'static'`, middleware never runs for
+// CDN-served pages, so a CSP set there only ever reached the one SSR API
+// route. And the hashes can't live in netlify.toml because the Sentry
+// integration injects an inline debug-ID script whose content (and therefore
+// hash) changes on every build. The only correct time to compute script
+// hashes is after the HTML exists.
+//
+// Non-executable script types (e.g. application/ld+json) don't need hashes —
+// CSP only gates scripts the browser would run. `style-src 'unsafe-inline'`
+// is retained deliberately: sonner injects a runtime <style> tag and view
+// transitions set inline style attributes.
+
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SCRIPT_RE = /<script([^>]*)>([\s\S]*?)<\/script>/gi;
+const EXECUTABLE_TYPES = new Set(['', 'module', 'text/javascript', 'application/javascript']);
+
+/** Collect sha256 CSP hashes for every executable inline script in an HTML string. */
+export function extractInlineScriptHashes(html) {
+	const hashes = new Set();
+	for (const [, attrs, body] of html.matchAll(SCRIPT_RE)) {
+		if (!body) continue;
+		if (/\ssrc\s*=/i.test(attrs)) continue;
+		const type = (attrs.match(/\stype\s*=\s*["']?([^"'\s>]+)/i)?.[1] ?? '').toLowerCase();
+		if (!EXECUTABLE_TYPES.has(type)) continue;
+		hashes.add(`'sha256-${createHash('sha256').update(body).digest('base64')}'`);
+	}
+	return hashes;
+}
+
+/** Build the full CSP header value given a set of script hashes. */
+export function buildCsp(scriptHashes) {
+	const scriptSrc = ["'self'", ...[...scriptHashes].sort()].join(' ');
+	return [
+		"default-src 'self'",
+		`script-src ${scriptSrc}`,
+		"style-src 'self' 'unsafe-inline'",
+		"font-src 'self'",
+		"img-src 'self' data:",
+		"connect-src 'self' https://*.sentry.io https://*.ingest.us.sentry.io",
+		"worker-src 'self' blob:",
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+		"object-src 'none'",
+		'upgrade-insecure-requests',
+	].join('; ');
+}
+
+function findHtmlFiles(dir) {
+	const files = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) files.push(...findHtmlFiles(full));
+		else if (entry.name.endsWith('.html')) files.push(full);
+	}
+	return files;
+}
+
+/** Scan a build output directory and write its `_headers` file. Returns a summary. */
+export function generateHeaders(distDir) {
+	const htmlFiles = findHtmlFiles(distDir);
+	if (htmlFiles.length === 0) {
+		throw new Error(`No HTML files found under ${distDir} — did the build run?`);
+	}
+
+	const hashes = new Set();
+	for (const file of htmlFiles) {
+		for (const hash of extractInlineScriptHashes(readFileSync(file, 'utf8'))) {
+			hashes.add(hash);
+		}
+	}
+
+	const headersFile = `/*\n  Content-Security-Policy: ${buildCsp(hashes)}\n`;
+	writeFileSync(join(distDir, '_headers'), headersFile);
+	return { htmlFiles: htmlFiles.length, scriptHashes: hashes.size };
+}
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+if (isMain) {
+	try {
+		const distDir = fileURLToPath(new URL('../dist', import.meta.url));
+		const { htmlFiles, scriptHashes } = generateHeaders(distDir);
+		console.log(
+			`generate-headers: wrote dist/_headers (CSP with ${scriptHashes} inline script hash(es) from ${htmlFiles} HTML file(s))`,
+		);
+	} catch (err) {
+		console.error(`generate-headers: ${err instanceof Error ? err.message : err}`);
+		process.exit(1);
+	}
+}

--- a/scripts/generate-headers.mjs
+++ b/scripts/generate-headers.mjs
@@ -18,7 +18,8 @@ import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const SCRIPT_RE = /<script([^>]*)>([\s\S]*?)<\/script>/gi;
+// End tags may legally contain whitespace before '>' (e.g. `</script >`).
+const SCRIPT_RE = /<script([^>]*)>([\s\S]*?)<\/script\s*>/gi;
 const EXECUTABLE_TYPES = new Set(['', 'module', 'text/javascript', 'application/javascript']);
 
 /** Collect sha256 CSP hashes for every executable inline script in an HTML string. */

--- a/scripts/generate-headers.mjs
+++ b/scripts/generate-headers.mjs
@@ -18,8 +18,10 @@ import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-// End tags may legally contain whitespace before '>' (e.g. `</script >`).
-const SCRIPT_RE = /<script([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+// Browser tokenizers close a script element at `</script` followed by any
+// characters up to '>', including whitespace and stray attributes
+// (`</script >`, `</script bar>`), so match the same way.
+const SCRIPT_RE = /<script([^>]*)>([\s\S]*?)<\/script\b[^>]*>/gi;
 const EXECUTABLE_TYPES = new Set(['', 'module', 'text/javascript', 'application/javascript']);
 
 /** Collect sha256 CSP hashes for every executable inline script in an HTML string. */

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,9 +1,8 @@
-import { zodResolver } from '@hookform/resolvers/zod';
+import { standardSchemaResolver } from '@hookform/resolvers/standard-schema';
 import { Mail, MapPin } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
-import type { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
@@ -16,15 +15,15 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { formSchema } from '@/lib/schemas';
+import { type FormValues, formSchema } from '@/lib/schemas';
 
 const CONTACT_EMAIL = 'vyas0189@gmail.com';
 
 export function ContactForm() {
 	const [statusMessage, setStatusMessage] = useState('');
 
-	const form = useForm<z.infer<typeof formSchema>>({
-		resolver: zodResolver(formSchema),
+	const form = useForm<FormValues>({
+		resolver: standardSchemaResolver(formSchema),
 		mode: 'onSubmit',
 		reValidateMode: 'onChange',
 		defaultValues: {
@@ -34,7 +33,7 @@ export function ContactForm() {
 		},
 	});
 
-	async function onSubmit(values: z.infer<typeof formSchema>) {
+	async function onSubmit(values: FormValues) {
 		try {
 			const response = await fetch('/api/emails', {
 				method: 'POST',
@@ -58,6 +57,22 @@ export function ContactForm() {
 				const msg = 'Too many submissions. Please try again in a minute.';
 				setStatusMessage(msg);
 				toast.error(msg);
+				return;
+			}
+
+			if (response.status === 504) {
+				const msg = `The request timed out — your message may have gone through. If you don't hear back, email ${CONTACT_EMAIL} directly.`;
+				setStatusMessage(msg);
+				toast.error(
+					<>
+						The request timed out — your message may have gone through. If you don't hear back,
+						email{' '}
+						<a href={`mailto:${CONTACT_EMAIL}`} className="underline">
+							{CONTACT_EMAIL}
+						</a>{' '}
+						directly.
+					</>,
+				);
 				return;
 			}
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,9 @@
 import '@fontsource-variable/inter';
 import '@/styles/globals.css';
 import { ClientRouter } from 'astro:transitions';
+// Preload the latin variable font so text doesn't wait for CSS discovery.
+// Same asset the fontsource CSS references, so Vite emits one hashed URL.
+import interWoff2 from '@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url';
 
 interface Props {
 	title: string;
@@ -20,6 +23,7 @@ const ogImage = new URL(ogPath, Astro.site ?? Astro.url).toString();
 	<head>
 		<meta charset='utf-8' />
 		<meta name='viewport' content='width=device-width, initial-scale=1' />
+		<link rel='preload' as='font' type='font/woff2' href={interWoff2} crossorigin />
 		<meta name='description' content={description} />
 		<meta name='generator' content={Astro.generator} />
 		<link rel='canonical' href={Astro.url.href} />

--- a/src/lib/og-pages.ts
+++ b/src/lib/og-pages.ts
@@ -1,0 +1,32 @@
+// Single source of truth for OG image metadata. Layout.astro derives each
+// page's og:image URL from its pathname, so every page under src/pages must
+// have an entry here or its og:image 404s silently — a unit test
+// (tests/unit/og-pages.test.ts) enforces that.
+
+export interface PageMeta {
+	title: string;
+	description: string;
+}
+
+export const ogPages: Record<string, PageMeta> = {
+	index: {
+		title: 'Vyas Ramankulangara',
+		description: 'Software Engineer II — Houston, Texas',
+	},
+	about: {
+		title: 'About',
+		description: 'Education, experience, and certifications',
+	},
+	contact: {
+		title: 'Get in Touch',
+		description: 'Reach out via the contact form',
+	},
+	privacy: {
+		title: 'Privacy Policy',
+		description: 'How this site handles your data',
+	},
+	'404': {
+		title: 'Page not found',
+		description: "The page you requested doesn't exist",
+	},
+};

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -18,7 +18,7 @@
 // race is acceptable (worst case: a couple extra messages slip through per
 // cold start).
 
-import { createHmac, randomInt } from 'node:crypto';
+import { createHmac, randomBytes, randomInt } from 'node:crypto';
 import { getStore, type Store } from '@netlify/blobs';
 
 const RATE_LIMIT = 3;
@@ -35,9 +35,14 @@ const memoryStore = new Map<string, Entry>();
 
 let blobStore: Store | null | undefined;
 
+// HMAC salt for IP hashing. When RATE_LIMIT_SALT is unset (local dev), a
+// random per-process salt is generated instead of using any hardcoded value —
+// hashes then differ across instances, which only costs cross-instance bucket
+// continuity in environments that never set the var. Production sets it.
+const ipSalt = process.env.RATE_LIMIT_SALT || randomBytes(16).toString('hex');
+
 function hashIp(ip: string): string {
-	const salt = process.env.RATE_LIMIT_SALT || 'vyas-rate-limit-v1';
-	return createHmac('sha256', salt).update(ip).digest('hex').slice(0, 32);
+	return createHmac('sha256', ipSalt).update(ip).digest('hex').slice(0, 32);
 }
 
 function getBlobStore(): Store | null {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -18,13 +18,15 @@
 // race is acceptable (worst case: a couple extra messages slip through per
 // cold start).
 
-import { createHmac } from 'node:crypto';
+import { createHmac, randomInt } from 'node:crypto';
 import { getStore, type Store } from '@netlify/blobs';
 
 const RATE_LIMIT = 3;
 const RATE_WINDOW_MS = 60_000;
 const STALE_AFTER_MS = 60 * 60_000;
-const PRUNE_PROBABILITY = 0.1;
+// Sweep on ~1 in 10 requests. crypto.randomInt isn't needed for security here,
+// but it keeps static analyzers from flagging Math.random in security code.
+const PRUNE_ONE_IN = 10;
 const PRUNE_MAX_KEYS = 50;
 
 type Entry = { count: number; resetAt: number };
@@ -120,7 +122,7 @@ export async function checkRateLimit(ip: string): Promise<{
 
 	try {
 		const result = await checkInBlobs(store, key);
-		if (Math.random() < PRUNE_PROBABILITY) {
+		if (randomInt(PRUNE_ONE_IN) === 0) {
 			try {
 				await pruneStaleEntries(store);
 			} catch {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -7,22 +7,36 @@
 // `netlify dev`) the Blobs SDK throws on access, so we fall back to a
 // per-process Map.
 //
+// Privacy: keys are salted HMAC-SHA256 hashes of the caller's IP, never the
+// raw address (set RATE_LIMIT_SALT to rotate). Blobs has no TTL, so a small
+// probabilistic sweep deletes entries that have been stale for over an hour —
+// hashed IPs are not retained indefinitely.
+//
 // Note: Blobs is eventually-consistent. Concurrent requests from the same IP
 // in the exact same 100ms window could both see a stale count and both
 // succeed at the limit boundary. For a personal portfolio contact form this
 // race is acceptable (worst case: a couple extra messages slip through per
 // cold start).
 
+import { createHmac } from 'node:crypto';
 import { getStore, type Store } from '@netlify/blobs';
 
 const RATE_LIMIT = 3;
 const RATE_WINDOW_MS = 60_000;
+const STALE_AFTER_MS = 60 * 60_000;
+const PRUNE_PROBABILITY = 0.1;
+const PRUNE_MAX_KEYS = 50;
 
 type Entry = { count: number; resetAt: number };
 
 const memoryStore = new Map<string, Entry>();
 
 let blobStore: Store | null | undefined;
+
+function hashIp(ip: string): string {
+	const salt = process.env.RATE_LIMIT_SALT || 'vyas-rate-limit-v1';
+	return createHmac('sha256', salt).update(ip).digest('hex').slice(0, 32);
+}
 
 function getBlobStore(): Store | null {
 	if (blobStore !== undefined) return blobStore;
@@ -35,17 +49,17 @@ function getBlobStore(): Store | null {
 	return blobStore;
 }
 
-function checkInMemory(ip: string): {
+function checkInMemory(key: string): {
 	success: boolean;
 	remaining: number;
 	reset: number;
 } {
 	const now = Date.now();
-	const entry = memoryStore.get(ip);
+	const entry = memoryStore.get(key);
 
 	if (!entry || now > entry.resetAt) {
 		const resetAt = now + RATE_WINDOW_MS;
-		memoryStore.set(ip, { count: 1, resetAt });
+		memoryStore.set(key, { count: 1, resetAt });
 		return { success: true, remaining: RATE_LIMIT - 1, reset: resetAt };
 	}
 
@@ -60,10 +74,9 @@ function checkInMemory(ip: string): {
 
 async function checkInBlobs(
 	store: Store,
-	ip: string,
+	key: string,
 ): Promise<{ success: boolean; remaining: number; reset: number }> {
 	const now = Date.now();
-	const key = `ip:${ip}`;
 	const existing = (await store.get(key, { type: 'json' })) as Entry | null;
 
 	if (!existing || now > existing.resetAt) {
@@ -82,22 +95,45 @@ async function checkInBlobs(
 	};
 }
 
+// Blobs has no TTL, so occasionally sweep out long-stale entries. Bounded and
+// best-effort: a failed sweep never affects the caller's request.
+async function pruneStaleEntries(store: Store): Promise<void> {
+	const now = Date.now();
+	const { blobs } = await store.list();
+	for (const { key } of blobs.slice(0, PRUNE_MAX_KEYS)) {
+		const entry = (await store.get(key, { type: 'json' })) as Entry | null;
+		if (!entry || now > entry.resetAt + STALE_AFTER_MS) {
+			await store.delete(key);
+		}
+	}
+}
+
 export async function checkRateLimit(ip: string): Promise<{
 	success: boolean;
 	remaining: number;
 	reset: number;
 }> {
+	const key = `ip:${hashIp(ip)}`;
+
 	const store = getBlobStore();
-	if (!store) return checkInMemory(ip);
+	if (!store) return checkInMemory(key);
 
 	try {
-		return await checkInBlobs(store, ip);
+		const result = await checkInBlobs(store, key);
+		if (Math.random() < PRUNE_PROBABILITY) {
+			try {
+				await pruneStaleEntries(store);
+			} catch {
+				// best-effort cleanup; never affect the request
+			}
+		}
+		return result;
 	} catch (err) {
 		// Blobs unreachable mid-request — fall back to in-memory rather than
 		// failing the user's submission outright.
 		console.warn('rate-limit: Blobs unavailable, falling back to memory', {
 			name: (err as Error)?.name,
 		});
-		return checkInMemory(ip);
+		return checkInMemory(key);
 	}
 }

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,19 +1,29 @@
-import { z } from 'zod';
+// zod/mini keeps the client bundle small: the contact form imports this schema
+// in the browser, and mini's functional API tree-shakes far better than the
+// chainable classic API. Server code (api/emails.ts) shares the same schema.
+import * as z from 'zod/mini';
 
 export const formSchema = z.object({
 	name: z
 		.string({ error: 'Name is required' })
-		.trim()
-		.min(2, 'Please enter at least 2 characters for your name')
-		.max(100, 'Name must be 100 characters or fewer')
-		.regex(/^[^\r\n]+$/, 'Invalid characters'),
-	email: z
-		.string({ error: 'Email is required' })
-		.trim()
-		.email('Please enter a valid email address')
-		.max(254, 'Email must be 254 characters or fewer'),
+		.check(
+			z.trim(),
+			z.minLength(2, 'Please enter at least 2 characters for your name'),
+			z.maxLength(100, 'Name must be 100 characters or fewer'),
+			z.regex(/^[^\r\n]+$/, 'Invalid characters'),
+		),
+	email: z.pipe(
+		z.string({ error: 'Email is required' }).check(z.trim()),
+		z
+			.email({ error: 'Please enter a valid email address' })
+			.check(z.maxLength(254, 'Email must be 254 characters or fewer')),
+	),
 	message: z
 		.string({ error: 'Message is required' })
-		.min(10, 'Please enter at least 10 characters for your message')
-		.max(5000, 'Message must be 5000 characters or fewer'),
+		.check(
+			z.minLength(10, 'Please enter at least 10 characters for your message'),
+			z.maxLength(5000, 'Message must be 5000 characters or fewer'),
+		),
 });
+
+export type FormValues = z.infer<typeof formSchema>;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,55 +1,37 @@
 import { defineMiddleware } from 'astro:middleware';
 
+// CSRF origin check for API POST routes. This intentionally also covers
+// application/json bodies, which Astro's built-in `security.checkOrigin`
+// skips. Requiring the Origin header to be present means non-browser clients
+// are rejected — that's fine, the API only serves this site's contact form.
+//
+// Note: with `output: 'static'`, this middleware only runs for on-demand
+// routes (/api/*). Site-wide security headers live in netlify.toml, and the
+// Content-Security-Policy is generated post-build into dist/_headers by
+// scripts/generate-headers.mjs (its inline-script hashes change every build).
+
+const forbidden = () =>
+	new Response(JSON.stringify({ error: 'Forbidden' }), {
+		status: 403,
+		headers: { 'Content-Type': 'application/json' },
+	});
+
 export const onRequest = defineMiddleware(async (context, next) => {
-	// CSRF protection for API POST routes only
 	if (context.url.pathname.startsWith('/api/') && context.request.method === 'POST') {
 		const origin = context.request.headers.get('origin');
 		const host = context.request.headers.get('host');
 
-		if (!origin || !host) {
-			return new Response(JSON.stringify({ error: 'Forbidden' }), {
-				status: 403,
-				headers: { 'Content-Type': 'application/json' },
-			});
-		}
+		if (!origin || !host) return forbidden();
 
 		let originHost: string;
 		try {
 			originHost = new URL(origin).host;
 		} catch {
-			return new Response('Forbidden', { status: 403 });
+			return forbidden();
 		}
 
-		if (originHost !== host) {
-			return new Response(JSON.stringify({ error: 'Forbidden' }), {
-				status: 403,
-				headers: { 'Content-Type': 'application/json' },
-			});
-		}
+		if (originHost !== host) return forbidden();
 	}
 
-	const response = await next();
-
-	// Content-Security-Policy stays in middleware (will need per-route nonces eventually).
-	// Other security headers are configured in netlify.toml.
-	response.headers.set(
-		'Content-Security-Policy',
-		[
-			"default-src 'self'",
-			// TODO: migrate to nonces
-			"script-src 'self' 'unsafe-inline'",
-			"style-src 'self' 'unsafe-inline'",
-			"font-src 'self'",
-			"img-src 'self' data:",
-			"connect-src 'self' https://*.sentry.io https://*.ingest.us.sentry.io",
-			"worker-src 'self' blob:",
-			"frame-ancestors 'none'",
-			"base-uri 'self'",
-			"form-action 'self'",
-			"object-src 'none'",
-			'upgrade-insecure-requests',
-		].join('; '),
-	);
-
-	return response;
+	return next();
 });

--- a/src/pages/api/emails.ts
+++ b/src/pages/api/emails.ts
@@ -15,16 +15,25 @@ const RESEND_TO_EMAIL = import.meta.env.RESEND_TO_EMAIL || process.env.RESEND_TO
 
 const resend = new Resend(RESEND_API_KEY);
 
+class TimeoutError extends Error {
+	constructor() {
+		super('Resend request timed out');
+		this.name = 'TimeoutError';
+	}
+}
+
 export const POST: APIRoute = async ({ request, clientAddress }) => {
-	// Rate limiting
-	const ip = clientAddress || request.headers.get('x-forwarded-for') || 'unknown';
+	// Rate limiting. Deliberately no x-forwarded-for fallback: that header is
+	// client-controlled, which would let callers mint their own buckets. When
+	// the adapter can't supply an address, everyone shares the 'unknown' bucket.
+	const ip = clientAddress || 'unknown';
 	const limit = await checkRateLimit(ip);
 	if (!limit.success) {
 		return new Response(JSON.stringify({ error: 'Too many requests' }), {
 			status: 429,
 			headers: {
 				'Content-Type': 'application/json',
-				'Retry-After': '60',
+				'Retry-After': String(Math.max(1, Math.ceil((limit.reset - Date.now()) / 1000))),
 			},
 		});
 	}
@@ -77,6 +86,7 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 
 	const { name, email, message } = validation.data;
 
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
 	try {
 		const sendPromise = resend.emails.send({
 			from: `Vyas's Website <${RESEND_FROM_EMAIL}>`,
@@ -84,12 +94,12 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 			subject: 'Email from Contact Form',
 			react: React.createElement(ContactEmail, { name, email, message }),
 		});
+		// If the timeout wins the race, the send may still settle later — swallow
+		// that late rejection so it can't surface as an unhandled rejection.
+		sendPromise.catch(() => {});
 
 		const timeoutPromise = new Promise<never>((_, reject) => {
-			const id = setTimeout(() => {
-				clearTimeout(id);
-				reject(new Error('Resend request timed out'));
-			}, 8000);
+			timeoutId = setTimeout(() => reject(new TimeoutError()), 8000);
 		});
 
 		const { error } = (await Promise.race([sendPromise, timeoutPromise])) as Awaited<
@@ -133,6 +143,23 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 			headers: { 'Content-Type': 'application/json' },
 		});
 	} catch (e: unknown) {
+		if (e instanceof TimeoutError) {
+			// The send may still have completed after we stopped waiting — tell the
+			// user honestly rather than implying outright failure.
+			Sentry.captureException(e, {
+				tags: { route: 'emails', resend_status: 504 },
+			});
+			return new Response(
+				JSON.stringify({
+					error: 'The email service timed out. Your message may still have been sent.',
+				}),
+				{
+					status: 504,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			);
+		}
+
 		const err = e as { name?: string; code?: string; statusCode?: number } | undefined;
 		console.error('emails.handler.error', {
 			name: err?.name,
@@ -146,5 +173,14 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
 			status: 500,
 			headers: { 'Content-Type': 'application/json' },
 		});
+	} finally {
+		clearTimeout(timeoutId);
 	}
 };
+
+// Any method other than POST (Astro matches specific exports first).
+export const ALL: APIRoute = () =>
+	new Response(JSON.stringify({ error: 'Method not allowed' }), {
+		status: 405,
+		headers: { 'Content-Type': 'application/json', Allow: 'POST' },
+	});

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -1,37 +1,10 @@
 import { OGImageRoute } from 'astro-og-canvas';
+import { ogPages, type PageMeta } from '@/lib/og-pages';
 
 export const prerender = true;
 
-interface PageMeta {
-	title: string;
-	description: string;
-}
-
-const pages: Record<string, PageMeta> = {
-	index: {
-		title: 'Vyas Ramankulangara',
-		description: 'Software Engineer II — Houston, Texas',
-	},
-	about: {
-		title: 'About',
-		description: 'Education, experience, and certifications',
-	},
-	contact: {
-		title: 'Get in Touch',
-		description: 'Reach out via the contact form',
-	},
-	privacy: {
-		title: 'Privacy Policy',
-		description: 'How this site handles your data',
-	},
-	'404': {
-		title: 'Page not found',
-		description: "The page you requested doesn't exist",
-	},
-};
-
 export const { getStaticPaths, GET } = await OGImageRoute({
-	pages,
+	pages: ogPages,
 	getImageOptions: (_slug, page: PageMeta) => ({
 		title: page.title,
 		description: page.description,

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,7 +3,7 @@ import Footer from '@/components/Footer.astro';
 import Navigation from '@/components/Navigation.astro';
 import Layout from '@/layouts/Layout.astro';
 
-const lastUpdated = '2026-05-27';
+const lastUpdated = '2026-07-25';
 ---
 
 <Layout title="Privacy Policy — Vyas Ramankulangara" description="How this site handles your data.">
@@ -20,7 +20,7 @@ const lastUpdated = '2026-05-27';
 
       <section>
         <h2 class="text-2xl font-semibold mb-3">Contact form</h2>
-        <p>The contact form sends your name, email address, and message to my inbox via <a href="https://resend.com" rel="noopener noreferrer" class="underline">Resend</a>, a transactional email provider. Resend stores delivery metadata according to <a href="https://resend.com/legal/privacy-policy" rel="noopener noreferrer" class="underline">their privacy policy</a>. Submissions are rate-limited to prevent abuse.</p>
+        <p>The contact form sends your name, email address, and message to my inbox via <a href="https://resend.com" rel="noopener noreferrer" class="underline">Resend</a>, a transactional email provider. Resend stores delivery metadata according to <a href="https://resend.com/legal/privacy-policy" rel="noopener noreferrer" class="underline">their privacy policy</a>. Submissions are rate-limited to prevent abuse: a salted, irreversible hash of your IP address is kept briefly to enforce the limit and is automatically cleaned up — your raw IP address is never stored.</p>
       </section>
 
       <section>

--- a/tests/unit/generate-headers.test.ts
+++ b/tests/unit/generate-headers.test.ts
@@ -1,0 +1,80 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+// Plain .mjs module — imported relatively, outside the src/ alias.
+import {
+	buildCsp,
+	extractInlineScriptHashes,
+	generateHeaders,
+} from '../../scripts/generate-headers.mjs';
+
+function sha256(body: string): string {
+	return `'sha256-${createHash('sha256').update(body).digest('base64')}'`;
+}
+
+describe('extractInlineScriptHashes', () => {
+	it('hashes plain and module inline scripts', () => {
+		const html = `<html><head>
+			<script>console.log('a')</script>
+			<script type="module">console.log('b')</script>
+		</head></html>`;
+		const hashes = extractInlineScriptHashes(html);
+		expect(hashes).toEqual(new Set([sha256("console.log('a')"), sha256("console.log('b')")]));
+	});
+
+	it('ignores external scripts, JSON-LD data blocks, and empty bodies', () => {
+		const html = `<html><head>
+			<script type="module" src="/_astro/page.js"></script>
+			<script type="application/ld+json">{"@context":"https://schema.org"}</script>
+			<script></script>
+		</head></html>`;
+		expect(extractInlineScriptHashes(html).size).toBe(0);
+	});
+
+	it('dedupes identical scripts across occurrences', () => {
+		const html = '<script>x()</script><script>x()</script>';
+		expect(extractInlineScriptHashes(html).size).toBe(1);
+	});
+});
+
+describe('buildCsp', () => {
+	it('includes hashes in script-src and keeps core directives', () => {
+		const csp = buildCsp(new Set(["'sha256-abc'"]));
+		expect(csp).toContain("script-src 'self' 'sha256-abc'");
+		expect(csp).toContain("default-src 'self'");
+		expect(csp).toContain("frame-ancestors 'none'");
+		expect(csp).toContain("object-src 'none'");
+		expect(csp).toContain("base-uri 'self'");
+		expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
+	});
+});
+
+describe('generateHeaders', () => {
+	let dir: string;
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('writes a _headers file covering all pages with the union of hashes', () => {
+		dir = mkdtempSync(join(tmpdir(), 'gen-headers-'));
+		writeFileSync(join(dir, 'index.html'), '<script>a()</script>');
+		mkdirSync(join(dir, 'about'));
+		writeFileSync(join(dir, 'about', 'index.html'), '<script>b()</script>');
+
+		const result = generateHeaders(dir);
+		expect(result).toEqual({ htmlFiles: 2, scriptHashes: 2 });
+
+		const headers = readFileSync(join(dir, '_headers'), 'utf8');
+		expect(headers.startsWith('/*\n  Content-Security-Policy: ')).toBe(true);
+		expect(headers).toContain(sha256('a()'));
+		expect(headers).toContain(sha256('b()'));
+	});
+
+	it('throws when the build output has no HTML', () => {
+		dir = mkdtempSync(join(tmpdir(), 'gen-headers-'));
+		expect(() => generateHeaders(dir)).toThrow(/No HTML files/);
+	});
+});

--- a/tests/unit/generate-headers.test.ts
+++ b/tests/unit/generate-headers.test.ts
@@ -38,9 +38,12 @@ describe('extractInlineScriptHashes', () => {
 		expect(extractInlineScriptHashes(html).size).toBe(1);
 	});
 
-	it('matches end tags containing whitespace, per the HTML spec', () => {
-		const html = '<script>a()</script ><script type="module">b()</script\n>';
-		expect(extractInlineScriptHashes(html)).toEqual(new Set([sha256('a()'), sha256('b()')]));
+	it('matches end tags with whitespace or stray attributes, like browser tokenizers', () => {
+		const html =
+			'<script>a()</script ><script type="module">b()</script\n>' + '<script>c()</script\t\n bar>';
+		expect(extractInlineScriptHashes(html)).toEqual(
+			new Set([sha256('a()'), sha256('b()'), sha256('c()')]),
+		);
 	});
 });
 

--- a/tests/unit/generate-headers.test.ts
+++ b/tests/unit/generate-headers.test.ts
@@ -37,6 +37,11 @@ describe('extractInlineScriptHashes', () => {
 		const html = '<script>x()</script><script>x()</script>';
 		expect(extractInlineScriptHashes(html).size).toBe(1);
 	});
+
+	it('matches end tags containing whitespace, per the HTML spec', () => {
+		const html = '<script>a()</script ><script type="module">b()</script\n>';
+		expect(extractInlineScriptHashes(html)).toEqual(new Set([sha256('a()'), sha256('b()')]));
+	});
 });
 
 describe('buildCsp', () => {

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -6,8 +6,6 @@ vi.mock('astro:middleware', () => ({
 	defineMiddleware: (fn: unknown) => fn,
 }));
 
-const CSP_HEADER = 'Content-Security-Policy';
-
 type OnRequestFn = (
 	context: { url: URL; request: Request },
 	next: () => Promise<Response>,
@@ -27,7 +25,7 @@ describe('middleware onRequest', () => {
 		vi.clearAllMocks();
 	});
 
-	it('GET request to / passes through and sets CSP header', async () => {
+	it('GET request to / passes through untouched', async () => {
 		const onRequest = await loadOnRequest();
 		const next = makeNext();
 		const response = await onRequest(
@@ -40,8 +38,6 @@ describe('middleware onRequest', () => {
 
 		expect(next).toHaveBeenCalledTimes(1);
 		expect(response.status).toBe(200);
-		expect(response.headers.get(CSP_HEADER)).toBeTruthy();
-		expect(response.headers.get(CSP_HEADER)).toContain("default-src 'self'");
 	});
 
 	it('POST to /api/emails with valid same-origin passes and calls next', async () => {
@@ -63,7 +59,6 @@ describe('middleware onRequest', () => {
 
 		expect(next).toHaveBeenCalledTimes(1);
 		expect(response.status).toBe(200);
-		expect(response.headers.get(CSP_HEADER)).toBeTruthy();
 	});
 
 	it('POST to /api/emails with no Origin header returns 403', async () => {
@@ -133,7 +128,7 @@ describe('middleware onRequest', () => {
 		expect(response.status).toBe(403);
 	});
 
-	it('POST to /api/emails with malformed Origin returns 403, not 500', async () => {
+	it('POST to /api/emails with malformed Origin returns a JSON 403, not 500', async () => {
 		const onRequest = await loadOnRequest();
 		const next = makeNext();
 		const response = await onRequest(
@@ -152,6 +147,8 @@ describe('middleware onRequest', () => {
 
 		expect(next).not.toHaveBeenCalled();
 		expect(response.status).toBe(403);
+		expect(response.headers.get('Content-Type')).toBe('application/json');
+		await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
 	});
 
 	it('POST to a non-/api/ path skips CSRF check and passes', async () => {
@@ -170,24 +167,5 @@ describe('middleware onRequest', () => {
 
 		expect(next).toHaveBeenCalledTimes(1);
 		expect(response.status).toBe(200);
-	});
-
-	it('always sets the CSP header on successful responses', async () => {
-		const onRequest = await loadOnRequest();
-		const next = makeNext();
-		const response = await onRequest(
-			{
-				url: new URL('http://localhost:4321/about'),
-				request: new Request('http://localhost:4321/about', { method: 'GET' }),
-			},
-			next,
-		);
-
-		const csp = response.headers.get(CSP_HEADER);
-		expect(csp).toBeTruthy();
-		// Spot-check a few directives that should be present.
-		expect(csp).toContain("frame-ancestors 'none'");
-		expect(csp).toContain("object-src 'none'");
-		expect(csp).toContain("base-uri 'self'");
 	});
 });

--- a/tests/unit/og-pages.test.ts
+++ b/tests/unit/og-pages.test.ts
@@ -1,0 +1,38 @@
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { ogPages } from '@/lib/og-pages';
+
+// Layout.astro derives each page's og:image URL from its pathname, so a page
+// without an ogPages entry ships a broken og:image that nothing else catches.
+
+function pageSlugs(): string[] {
+	const pagesDir = join(process.cwd(), 'src/pages');
+	return readdirSync(pagesDir)
+		.filter((name) => name.endsWith('.astro'))
+		.map((name) => name.replace(/\.astro$/, ''));
+}
+
+describe('ogPages map', () => {
+	it('has an entry for every top-level .astro page', () => {
+		for (const slug of pageSlugs()) {
+			expect(ogPages[slug], `src/pages/${slug}.astro has no ogPages entry`).toBeDefined();
+		}
+	});
+
+	it('has no stale entries for pages that no longer exist', () => {
+		const slugs = new Set(pageSlugs());
+		for (const key of Object.keys(ogPages)) {
+			expect(slugs.has(key), `ogPages entry "${key}" has no matching src/pages/${key}.astro`).toBe(
+				true,
+			);
+		}
+	});
+
+	it('every entry has a non-empty title and description', () => {
+		for (const [key, meta] of Object.entries(ogPages)) {
+			expect(meta.title.length, `${key} title`).toBeGreaterThan(0);
+			expect(meta.description.length, `${key} description`).toBeGreaterThan(0);
+		}
+	});
+});

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -5,6 +5,9 @@ beforeEach(() => {
 	// Blobs getStore lookup) via re-import.
 	vi.resetModules();
 	vi.unstubAllEnvs();
+	// Without a configured salt the module generates a random per-process one on
+	// each import — pin it so hashed keys stay stable across re-imports.
+	vi.stubEnv('RATE_LIMIT_SALT', 'test-salt');
 });
 
 // --- helpers ---

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,12 +10,8 @@ export default defineConfig({
 				test: {
 					name: 'node',
 					environment: 'node',
-					include: [
-						'tests/unit/schemas.test.ts',
-						'tests/unit/utils.test.ts',
-						'tests/unit/middleware.test.ts',
-						'tests/unit/rate-limit.test.ts',
-					],
+					// All plain-TS unit tests; .tsx component tests run in the dom project.
+					include: ['tests/unit/**/*.test.ts'],
 				},
 				resolve: { alias: { '@': resolve(__dirname, './src') } },
 			},


### PR DESCRIPTION
## Summary

Implements every finding from the security/performance audit (OWASP, Astro-specifics, Core Web Vitals).

### Security
- **CSP now ships on every page** — previously the CSP lived in middleware, which with `output: 'static'` only runs for `/api/emails`; verified the built output had **no CSP on any HTML page**. It's now generated post-build into `dist/_headers` by `scripts/generate-headers.mjs` (new `postbuild` script), computing per-build sha256 hashes for inline scripts. This also removes `'unsafe-inline'` from `script-src` — hashes must be per-build because Sentry injects a debug-ID snippet that changes every deploy.
- Middleware reduced to CSRF-only; malformed-Origin 403 now JSON.
- Rate limiter: salted HMAC-SHA256 of IPs instead of raw addresses (optional `RATE_LIMIT_SALT`), plus probabilistic pruning of stale Blobs entries (Blobs has no TTL). Privacy policy updated to disclose this.
- Dropped the spoofable `x-forwarded-for` rate-limit fallback.
- Resend timeout: timer cleared via `finally`, late rejection swallowed, 504 (was 500) with "may have been sent" copy on server and client; dynamic `Retry-After` on 429.
- Explicit `405` + `Allow: POST` for other methods on the API route.

### Performance
- `prefetchAll: true` — the old config prefetched nothing (no link had `data-astro-prefetch`).
- Preload Inter latin variable woff2 (cuts first-visit FOUT).
- Contact form → `zod/mini` + `standardSchemaResolver`: contact-form chunk now **28.9 KB gz** (budget 50 KB); also clears the deprecated `.email()` typecheck hint.

### Maintenance
- OG page map extracted to `src/lib/og-pages.ts` + unit test so a new page can't silently ship a 404 `og:image`.
- vitest node project now globs `tests/unit/**/*.test.ts` — newly added test files were silently not running.
- Removed dead `/fonts/*` header rule; CLAUDE.md updated to match reality (Astro 7, actual middleware/CSP architecture).

## Test plan
- [x] `npm run lint` / `format:check` — clean
- [x] `npm run typecheck` — 0 errors, 0 hints
- [x] `npm run test:unit` — 49 passed (7 files, incl. new generator + og-map suites)
- [x] `npm run build` — `dist/_headers` generated with 5 script hashes, font preload present
- [x] Bundle budgets verified by hand (size-limit's Chrome helper can't launch in local sandbox; CI runs it)
- [ ] CI: E2E + Lighthouse + size-limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)